### PR TITLE
feat(qdt): update url for json schema

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
         files: ^profiles/.*\.json$
         args:
           - --schemafile
-          - https://raw.githubusercontent.com/Guts/qgis-deployment-cli/main/docs/schemas/profile/qgis_profile.json
+          - https://raw.githubusercontent.com/qgis-deployment/qgis-deployment-toolbelt-cli/main/docs/schemas/profile/qgis_profile.json
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.28.0
@@ -45,10 +45,8 @@ repos:
         args:
           - --default-filetype
           - yaml
-          - --base-uri
-          - https://raw.githubusercontent.com/Guts/qgis-deployment-cli/main/docs/schemas/scenario/
           - --schemafile
-          - https://raw.githubusercontent.com/Guts/qgis-deployment-cli/main/docs/schemas/scenario/schema.json
+          - https://raw.githubusercontent.com/qgis-deployment/qgis-deployment-toolbelt-cli/main/docs/schemas/scenario/qdt_scenario.json
 
 ci:
   autoupdate_schedule: quarterly

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,7 @@
         "requirements*.txt": "pip-requirements"
     },
     "yaml.schemas": {
-        "https://raw.githubusercontent.com/Guts/qgis-deployment-cli/main/docs/schemas/scenario/schema.json": [
+        "https://raw.githubusercontent.com/qgis-deployment/qgis-deployment-toolbelt-cli/main/docs/schemas/scenario/schema.json": [
             "**/*scenario*qdt.yml"
         ]
     },

--- a/profiles/Loire_aval/profile.json
+++ b/profiles/Loire_aval/profile.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Guts/qgis-deployment-cli/main/docs/schemas/profile/qgis_profile.json",
+  "$schema": "https://raw.githubusercontent.com/qgis-deployment/qgis-deployment-toolbelt-cli/main/docs/schemas/profile/qgis_profile.json",
   "name": "loire_aval",
   "description": "Profil pour les utilisateurs situés sur la Loire aval, De la confluence de l'Indre jusqu'à la mer.",
   "author": "Emilie BIGORNE",
@@ -30,22 +30,20 @@
       "version": "1.1.",
       "official_repository": true,
       "plugin_id": 1846
-    }
-    ,
+    },
     {
       "name": "Custom News Feed",
       "folder_name": "custom_news_feed",
       "version": "v1.2.3",
       "official_repository": true,
       "plugin_id": 2691
-    }  
-    ,
+    },
     {
       "name": "Data Plotly",
       "folder_name": "DataPlotly",
       "version": "4.1.0",
       "official_repository": true,
       "plugin_id": 1247
-    } 
+    }
   ]
 }

--- a/profiles/axe_loire/profile.json
+++ b/profiles/axe_loire/profile.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Guts/qgis-deployment-cli/main/docs/schemas/profile/qgis_profile.json",
+  "$schema": "https://raw.githubusercontent.com/qgis-deployment/qgis-deployment-toolbelt-cli/main/docs/schemas/profile/qgis_profile.json",
   "name": "axe_loire",
   "description": "Profil pour les utilisateurs situés sur l'axe Loire, de la confluence avec l'Allier jusq'à la confluence avec l'Indre",
   "author": "Emilie BIGORNE",
@@ -30,22 +30,20 @@
       "version": "1.1.1",
       "official_repository": true,
       "plugin_id": 1846
-    }
-    ,
+    },
     {
       "name": "Custom News Feed",
       "folder_name": "custom_news_feed",
       "version": "v1.2.3",
       "official_repository": true,
       "plugin_id": 2691
-    }
-    ,
+    },
     {
       "name": "Data Plotly",
       "folder_name": "DataPlotly",
       "version": "4.1.0",
       "official_repository": true,
       "plugin_id": 1247
-    }       
+    }
   ]
 }

--- a/profiles/cher/profile.json
+++ b/profiles/cher/profile.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Guts/qgis-deployment-cli/main/docs/schemas/profile/qgis_profile.json",
+  "$schema": "https://raw.githubusercontent.com/qgis-deployment/qgis-deployment-toolbelt-cli/main/docs/schemas/profile/qgis_profile.json",
   "name": "cher",
   "description": "Profil pour les utilisateurs situés sur le bassin du Cher.",
   "author": "Emilie BIGORNE",
@@ -30,22 +30,20 @@
       "version": "1.1.1",
       "official_repository": true,
       "plugin_id": 1846
-    }
-    ,
+    },
     {
       "name": "Custom News Feed",
       "folder_name": "custom_news_feed",
       "version": "v1.2.3",
       "official_repository": true,
       "plugin_id": 2691
-    }
-    ,
+    },
     {
       "name": "Data Plotly",
       "folder_name": "DataPlotly",
       "version": "4.1.0",
       "official_repository": true,
       "plugin_id": 1247
-    }   
+    }
   ]
 }

--- a/profiles/haut_bassin/profile.json
+++ b/profiles/haut_bassin/profile.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Guts/qgis-deployment-cli/main/docs/schemas/profile/qgis_profile.json",
+  "$schema": "https://raw.githubusercontent.com/qgis-deployment/qgis-deployment-toolbelt-cli/main/docs/schemas/profile/qgis_profile.json",
   "name": "haut_bassin",
   "description": "Profil pour les utilisateurs situés sur la haut bassin de la Loire : bassin de l'Allier et de la Loire en amont de leur confluence",
   "author": "Emilie BIGORNE",
@@ -30,22 +30,20 @@
       "version": "1.1.1",
       "official_repository": true,
       "plugin_id": 1846
-    }
-    ,
+    },
     {
       "name": "Custom News Feed",
       "folder_name": "custom_news_feed",
       "version": "v1.2.3",
       "official_repository": true,
       "plugin_id": 2691
-    }
-    ,
+    },
     {
       "name": "Data Plotly",
       "folder_name": "DataPlotly",
       "version": "4.1.0",
       "official_repository": true,
       "plugin_id": 1247
-    } 
+    }
   ]
 }

--- a/profiles/maine/profile.json
+++ b/profiles/maine/profile.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Guts/qgis-deployment-cli/main/docs/schemas/profile/qgis_profile.json",
+  "$schema": "https://raw.githubusercontent.com/qgis-deployment/qgis-deployment-toolbelt-cli/main/docs/schemas/profile/qgis_profile.json",
   "name": "maine",
   "description": "Profil pour les utilisateurs situés sur le bassin de la Maine",
   "author": "Emilie BIGORNE",
@@ -30,22 +30,20 @@
       "version": "1.1.1",
       "official_repository": true,
       "plugin_id": 1846
-    }
-    ,
+    },
     {
       "name": "Custom News Feed",
       "folder_name": "custom_news_feed",
       "version": "v1.2.3",
       "official_repository": true,
       "plugin_id": 2691
-    }  
-    ,
+    },
     {
       "name": "Data Plotly",
       "folder_name": "DataPlotly",
       "version": "4.1.0",
       "official_repository": true,
       "plugin_id": 1247
-    }     
+    }
   ]
 }

--- a/profiles/support/profile.json
+++ b/profiles/support/profile.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Guts/qgis-deployment-cli/main/docs/schemas/profile/qgis_profile.json",
+  "$schema": "https://raw.githubusercontent.com/qgis-deployment/qgis-deployment-toolbelt-cli/main/docs/schemas/profile/qgis_profile.json",
   "name": "EP Loire support",
   "folder_name": "epl_support",
   "description": "Test support",
@@ -31,22 +31,20 @@
       "version": "1.1.1",
       "official_repository": true,
       "plugin_id": 1846
-    }
-    ,
+    },
     {
       "name": "Custom News Feed",
       "folder_name": "custom_news_feed",
       "version": "v1.2.3",
       "official_repository": true,
       "plugin_id": 2691
-    } 
-    ,
+    },
     {
       "name": "Data Plotly",
       "folder_name": "DataPlotly",
       "version": "4.1.0",
       "official_repository": true,
       "plugin_id": 1247
-    }      
+    }
   ]
 }

--- a/qdt_scenarii/scenario.qdt.yml
+++ b/qdt_scenarii/scenario.qdt.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Guts/qgis-deployment-cli/main/docs/schemas/scenario/schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/qgis-deployment/qgis-deployment-toolbelt-cli/main/docs/schemas/scenario/schema.json
 
 metadata:
   title: "Profile EP Loire"
@@ -13,11 +13,10 @@ settings:
 
 # Deployment workflow, step by step
 steps:
-
   - name: Set environment variables
     uses: manage-env-vars
     with:
-      - name: QDT_QGIS_EXE_PATH 
+      - name: QDT_QGIS_EXE_PATH
         action: "add"
         scope: "user"
         value: "C:\\QGIS\\3_28\\bin\\qgis-ltr-bin.exe"
@@ -26,7 +25,7 @@ steps:
   - name: Set environment variables
     uses: manage-env-vars
     with:
-      - name: QDT_QGIS_EXE_PATH  
+      - name: QDT_QGIS_EXE_PATH
         action: "add"
         scope: "user"
         value: "C:\\QGIS\\3_34\\bin\\qgis-ltr-bin.exe"
@@ -35,10 +34,10 @@ steps:
   - name: Find installed QGIS
     uses: qgis-installation-finder
     with:
-      version_priority:
-        - "3.34"
-        - "3.28"
-      if_not_found: error
+      - version_priority:
+          - "3.34"
+          - "3.28"
+      - if_not_found: error
 
   - name: Download profiles from remote git repository
     uses: qprofiles-downloader
@@ -88,28 +87,28 @@ steps:
           start_menu: true
           additional_arguments: "--noversioncheck"
           action: create_or_restore
-          icon: "images/qgis_icone_eploire.ico"    
+          icon: "images/qgis_icone_eploire.ico"
         - profile: haut_bassin
           label: "Qgis Allier et Loire amont"
           desktop: true
           start_menu: true
           additional_arguments: "--noversioncheck"
           action: create_or_restore
-          icon: "images/qgis_icone_eploire.ico"        
+          icon: "images/qgis_icone_eploire.ico"
         - profile: loire_aval
           label: "Qgis Loire aval"
           desktop: true
           start_menu: true
           additional_arguments: "--noversioncheck"
           action: create_or_restore
-          icon: "images/qgis_icone_eploire.ico"      
+          icon: "images/qgis_icone_eploire.ico"
         - profile: maine
           label: "QGis bassin de la Maine"
           desktop: true
           start_menu: true
           additional_arguments: "--noversioncheck"
           action: create_or_restore
-          icon: "images/qgis_icone_eploire.ico"                                   
+          icon: "images/qgis_icone_eploire.ico"
   - name: Set splash screen
     uses: splash-screen-manager
     with:


### PR DESCRIPTION
le dépot de QDT a été déplacé de 

https://github.com/Guts/qgis-deployment-cli/

vers

https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli

Cette PR met à jour les références de json-schema pour la bonne url.  A noter que des commit ont récémment été effectués sur QDT pour corriger des petites erreurs de json-schema.

Il y a aussi une petite correction sur le job `qgis-installation-finder` la documentation a été mise à jour coté QDT pour indiquer un bon exemple. 

